### PR TITLE
Lineage groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[0.3.0](https://github.com/sanger-tol/busco/releases/tag/0.3.0)] – Lincolnshire – [2026-05-XX]
+
+### Enhancements & fixes
+- Lineage handling has been improved to support:
+    - `ALL` - Which runs all lineages found in the lineage directory
+    - `odb{int}` - Which runs all lineages with the suffix `odb{int}`
+    - `{lineage}` - Without the `odb` suffix, will find the odbs with the prefix `{lineage}`
+    - "{lineage}_odb{int},{lineage}_odb{int}" - Lists are still supported
+    - All options, other than providing a list, are not supported without also using the `--busco_db` option.
+    - Be aware that running `ALL`, can result in 691 jobs submitted. 
+
+
 ## [[0.2.0](https://github.com/sanger-tol/busco/releases/tag/0.2.0)] – Bedfordshire – [2026-05-19]
 
 Pipeline reset. In this new form, **sanger-tol/busco** is there to help running BUSCO

--- a/assets/samplesheet_allodb.csv
+++ b/assets/samplesheet_allodb.csv
@@ -1,0 +1,7 @@
+fasta,lineage,outdir
+https://tolit.cog.sanger.ac.uk/test-data/Meles_meles/assembly/release/mMelMel3.1_paternal_haplotype/GCA_922984935.2.subset.phiXspike.fasta.gz,odb12,Meles_meles.ALL_ODB12
+https://tolit.cog.sanger.ac.uk/test-data/Laetiporus_sulphureus/assembly/release/gfLaeSulp1.1/insdc/GCA_927399515.1.fasta.gz,odb10,Laetiporus_sulphureus.ALL_ODB10
+https://tolit.cog.sanger.ac.uk/test-data/Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz,ALL,Ceramica_pisi.ALL_ODBS
+https://tolit.cog.sanger.ac.uk/test-data/Ceramica_pisi/assembly/release/ilCerPisi1.1/insdc/GCA_963859965.1.fasta.gz,lepidoptera,Ceramica_pisi.ALL_LEP_ODBS
+https://tolit.cog.sanger.ac.uk/test-data/Laetiporus_sulphureus/assembly/release/gfLaeSulp1.1/insdc/GCA_927399515.1.fasta.gz,fungi_odb10,Laetiporus_sulphureus.FUNGI_ODB10
+https://tolit.cog.sanger.ac.uk/test-data/Laetiporus_sulphureus/assembly/release/gfLaeSulp1.1/insdc/GCA_927399515.1.fasta.gz,"fungi_odb10,eukaryota_odb12",Laetiporus_sulphureus.LIST_OF_ODB

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -15,7 +15,7 @@
             },
             "lineage": {
                 "type": "string",
-                "pattern": "_odb(10|12)$",
+                "pattern": "(odb(10|12))|(ALL)|([a-z]*)$",
                 "description": "Name of the ODB lineage to run BUSCO on. The pipeline defaults to the global --lineage parameter."
             },
             "outdir": {
@@ -24,6 +24,8 @@
                 "errorMessage": "Output directory for this assembly. Per-lineage sub-directories will be created under it. The pipeline defaults to the global --outdir parameter."
             }
         },
-        "required": ["fasta"]
+        "required": [
+            "fasta"
+        ]
     }
 }

--- a/conf/test_allodbs.config
+++ b/conf/test_allodbs.config
@@ -1,0 +1,19 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running full-size tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a full size pipeline test.
+
+    Use as follows:
+        nextflow run sanger-tol/busco -profile test_full,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Full test profile covering generalised odbs names'
+    config_profile_description = 'Full test dataset to check pipeline function'
+
+    // Path to a sample csv file
+    input = "${projectDir}/assets/samplesheet_allodb.csv"
+}

--- a/functions/local/utils.nf
+++ b/functions/local/utils.nf
@@ -1,0 +1,58 @@
+def normaliseLineage(lineage, lineage_path, sample_id) {
+    // A comma-separated string of fully-qualified lineage names (e.g. "fungi_odb10,eukaryota_odb10")
+    if (lineage.contains(',')) {
+        def lineage_list = lineage.tokenize(',')*.trim()
+        def invalid = lineage_list.findAll { !(it =~ /^.+_odb\d+$/) }
+        if (invalid) {
+            error "normaliseLineage: ${sample_id} - Items in list don't follow the {name}_odb{int} pattern: ${invalid}"
+        }
+        log.info "BUSCO [normaliseLineage]: ${sample_id} - Provided list – returning ${lineage_list.size()}"
+        return lineage_list
+    }
+
+    // A fully-qualified lineage (e.g. lepidoptera_odb10) is returned as-is
+    if (lineage =~ /^.+_odb\d+$/) {
+        return [lineage]
+    }
+
+    // Partial lineage queries require a lineage path to resolve against
+    // -- All fully-qualified lineages (e.g. lepidoptera_odb10) are checked by this point.
+    // -- We can't simply return all lineages unless we have the mapping file like in sanger-tol/blobtoolkit
+    if (!lineage_path) {
+        error "Cannot resolve lineage '${lineage}': please provide --busco_db pointing to a BUSCO download directory"
+    }
+
+    // BUSCO stores individual lineage datasets under <download_path>/lineages/
+    def lineages_dir = new File("${lineage_path}/lineages")
+    if (!lineages_dir.isDirectory()) {
+        error "Lineages directory not found: ${lineages_dir.absolutePath}"
+    }
+
+    // Collect all valid lineage directory names (pattern: <taxon>_odb<N>)
+    def all_lineages = lineages_dir.list()
+        ?.findAll { it =~ /^.+_odb\d+$/ }
+        ?.sort() ?: []
+
+    if (lineage == 'ALL') {
+        // Return every lineage available in the path
+        log.info "BUSCO [normaliseLineage]: ${sample_id} - '${lineage}' == returns ${all_lineages.size()} odb files"
+        return all_lineages
+    } else if (lineage =~ /^odb\d+$/) {
+        // e.g. "odb10" or "odb12" – return all lineages with that version suffix
+        all_found_lineages = all_lineages.findAll { it.endsWith("_${lineage}") }
+
+        // if the user has input a lineage and we can't find any lineages with that suffix,
+        // it's likely they were expecting it to be there, so error out.
+        if (!all_found_lineages) {
+            error "No lineages found for odb version: ${lineage}"
+        }
+
+        log.info "BUSCO [normaliseLineage]: ${sample_id} - '${lineage}' == returns ${all_found_lineages.size()} odb files"
+        return all_found_lineages
+    } else {
+        // Partial taxon name, e.g. "lepidoptera" – return all lineages with that prefix
+        def taxon_lineages = all_lineages.findAll { it.startsWith("${lineage}_") }
+        log.info "BUSCO [normaliseLineage]: ${sample_id} - '${lineage}' == returns ${taxon_lineages.size()} odb files"
+        return taxon_lineages
+    }
+}


### PR DESCRIPTION
### Enhancements & fixes
- Lineage handling has been improved to support:
    - `ALL` - Which runs all lineages found in the lineage directory
    - `odb{int}` - Which runs all lineages with the suffix `odb{int}`
    - `{lineage}` - Without the `odb` suffix, will find the odbs with the prefix `{lineage}`
    - "{lineage}_odb{int},{lineage}_odb{int}" - Lists are still supported
    - All options, other than providing a list, are not supported without also using the `--busco_db` option. This will cause an error.
    - Be aware that running `ALL`, can result in 691 jobs submitted. 